### PR TITLE
Fix plaintext password in setup script

### DIFF
--- a/scripts/add-user.js
+++ b/scripts/add-user.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+
+/**
+ * LCT Authentication - Add User Script
+ * 
+ * This script adds a new user to the database with hashed password.
+ * Usage: node scripts/add-user.js "email@example.com" "password"
+ */
+
+// Load environment variables from .env file
+require('dotenv').config();
+
+const { Client } = require('pg');
+const bcrypt = require('bcryptjs');
+
+async function addUser(email, password) {
+  let client;
+  try {
+    console.log(`🔧 Adding user: ${email}`);
+    
+    // Create database client with direct connection
+    client = new Client({
+      connectionString: process.env.POSTGRES_URL
+    });
+    
+    await client.connect();
+    console.log('✅ Connected to database');
+    
+    // Validate inputs
+    if (!email || !password) {
+      throw new Error('Email and password are required');
+    }
+    
+    if (!email.includes('@')) {
+      throw new Error('Invalid email format');
+    }
+    
+    if (password.length < 6) {
+      throw new Error('Password must be at least 6 characters');
+    }
+    
+    // Hash the password
+    console.log('🔐 Hashing password...');
+    const saltRounds = 12;
+    const passwordHash = await bcrypt.hash(password, saltRounds);
+    
+    // Check if user already exists
+    const existingUser = await client.query(
+      'SELECT id FROM users WHERE email = $1',
+      [email]
+    );
+    
+    if (existingUser.rows.length > 0) {
+      console.log('⚠️  User already exists. Updating password...');
+      
+      // Update existing user
+      await client.query(
+        'UPDATE users SET password_hash = $1, created_at = CURRENT_TIMESTAMP WHERE email = $2',
+        [passwordHash, email]
+      );
+      
+      console.log('✅ User password updated successfully');
+    } else {
+      // Insert new user
+      await client.query(
+        'INSERT INTO users (email, password_hash) VALUES ($1, $2)',
+        [email, passwordHash]
+      );
+      
+      console.log('✅ User created successfully');
+    }
+    
+    console.log('🎉 User setup complete!');
+    console.log(`📧 Email: ${email}`);
+    console.log('🔐 Password: [hidden for security]');
+    console.log('📝 You can now test login at: /login.html');
+    
+  } catch (error) {
+    console.error('❌ Failed to add user:', error.message);
+    console.error('💡 Make sure:');
+    console.error('   - Database is set up (run: node scripts/setup-database.js)');
+    console.error('   - LCT_Commit_PRISMA_DATABASE_URL environment variable is configured');
+    console.error('   - You have run: npm install');
+    process.exit(1);
+  } finally {
+    // Close the database connection
+    if (client) {
+      await client.end();
+    }
+  }
+}
+
+// Get command line arguments
+const email = process.argv[2];
+const password = process.argv[3];
+
+if (!email || !password) {
+  console.log('Usage: node scripts/add-user.js "email@example.com" "password"');
+  console.log('Example: node scripts/add-user.js "user@example.com" "your_secure_password"');
+  process.exit(1);
+}
+
+// Run if called directly
+if (require.main === module) {
+  addUser(email, password);
+}
+
+module.exports = { addUser };

--- a/scripts/setup-database.js
+++ b/scripts/setup-database.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * LCT Authentication - Database Setup Script
+ * 
+ * This script creates the users table in Vercel Postgres database.
+ * Run with: node scripts/setup-database.js
+ */
+
+// Load environment variables from .env file
+require('dotenv').config();
+
+const { Client } = require('pg');
+
+async function setupDatabase() {
+  let client;
+  try {
+    console.log('🔧 Setting up LCT authentication database...');
+    
+    // Create database client with direct connection
+    client = new Client({
+      connectionString: process.env.POSTGRES_URL
+    });
+    
+    await client.connect();
+    console.log('✅ Connected to database');
+    
+    // Create users table
+    const createTableQuery = `
+      CREATE TABLE IF NOT EXISTS users (
+        id SERIAL PRIMARY KEY,
+        email VARCHAR(255) UNIQUE NOT NULL,
+        password_hash TEXT NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        last_login TIMESTAMP
+      );
+    `;
+    
+    await client.query(createTableQuery);
+    console.log('✅ Users table created successfully');
+    
+    // Create index on email for faster lookups
+    const createIndexQuery = `
+      CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+    `;
+    
+    await client.query(createIndexQuery);
+    console.log('✅ Email index created');
+    
+    console.log('🎉 Database setup complete!');
+    console.log('📝 Next steps:');
+    console.log('   1. Run: node scripts/add-user.js "email@example.com" "your_password"');
+    console.log('   2. Test login at: /login.html');
+    
+  } catch (error) {
+    console.error('❌ Database setup failed:', error.message);
+    console.error('💡 Make sure:');
+    console.error('   - Vercel Postgres is set up in your project');
+    console.error('   - LCT_Commit_PRISMA_DATABASE_URL environment variable is configured');
+    console.error('   - You have run: npm install');
+    process.exit(1);
+  } finally {
+    // Close the database connection
+    if (client) {
+      await client.end();
+    }
+  }
+}
+
+// Run if called directly
+if (require.main === module) {
+  setupDatabase();
+}
+
+module.exports = { setupDatabase };


### PR DESCRIPTION
## 📋 Summary
Removed hardcoded plaintext passwords from console output in `setup-database.js` and `add-user.js` scripts to prevent credential leakage, replacing them with secure placeholders.

## 👥 Reviewers & Approvers
**Reviewers:**
- @codex
- @coderabbitai

**Approver:**
- @ak-eyther

---

## 🎯 Related Criteria
**Category 1: Clinical Accuracy**
- [ ] #1 - ICD matches billed service
- [ ] #2 - Service-Diagnosis consistency
- [ ] #3 - Medical notes completeness

**Category 2: Financial & Policy Compliance**
- [ ] #4 - Invoice amount precedence (CRITICAL)
- [ ] #5 - Invoice date within policy
- [ ] #6 - Preauthorization linkage
- [ ] #7 - Benefit-level savings tracking
- [ ] #8 - Service-level savings tracking
- [ ] #9 - Tariff and price validation (CRITICAL)

**Category 3: Fraud & Duplication Safeguards**
- [ ] #10 - Duplicate visit detection
- [ ] #11 - Repeated service detection (CRITICAL)
- [ ] #12 - Invoice number format consistency
- [ ] #13 - Remove non-alphanumeric characters
- [ ] #14 - Member visit frequency anomaly
- [ ] #15 - Cross-provider duplicate service (CRITICAL)
- [ ] #16 - Medication refill pattern analysis
- [ ] #17 - Provider billing pattern anomalies
- [ ] #18 - Benefit exhaustion velocity
- [ ] #19 - Family unit fraud pattern
- [ ] #20 - Geographic location mismatch
- [ ] #21 - Diagnosis-service historical validation
- [ ] #22 - High-cost service clustering
- [ ] #23 - Provider rejection rate trending
- [ ] #24 - Claim threshold manipulation
- [ ] #25 - Seasonal/temporal fraud patterns
- [ ] #26 - Chronic condition consistency
- [ ] #27 - Provider service scope validation

**Category 4: Vetting Completeness**
- [ ] #28 - 100% vetting completeness
- [ ] #29 - Query criteria definition

**Category 5: Process Efficiency**
- [ ] #30 - Vetting TAT
- [ ] #31 - Cost savings tracking

**Other**
- [x] N/A - Infrastructure/tooling/documentation (Security best practice)

## 🔧 Changes Made
-   Created `scripts/setup-database.js` and `scripts/add-user.js` files.
-   In `scripts/setup-database.js`, replaced the hardcoded password example with `"email@example.com" "your_password"` in the console output.
-   In `scripts/add-user.js`, replaced the hardcoded password example with `"user@example.com" "your_secure_password"` in the console output.

## ✅ Testing Done
- [ ] Tested manually in browser (opened HTML file)
- [x] Verified functionality works as expected
- [ ] Checked edge cases
- [x] No console errors or warnings
- [ ] Export/save functionality works (if applicable)

### Test Scenarios
1.  Verified that `scripts/setup-database.js` now outputs a generic placeholder for the password.
2.  Verified that `scripts/add-user.js` now outputs a generic placeholder for the password in its usage example.
3.  Confirmed that no hardcoded plaintext passwords are present in the console output of these scripts.
4.  Ensured both scripts are executable.

## 📸 Screenshots
N/A

## 🎯 Priority Level
- [ ] CRITICAL - Blocks 90% accuracy goal
- [x] High - Important for quality metrics
- [ ] Medium - Improves user experience
- [ ] Low - Nice to have

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

---
Linear Issue: [VIT-29](https://linear.app/vitraya-ak/issue/VIT-29/ai-review-high-pr-31-feat-implement-authentication-system)

<a href="https://cursor.com/background-agent?bcId=bc-1257d5a5-afe2-4af0-bf5c-26e20fbc1a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1257d5a5-afe2-4af0-bf5c-26e20fbc1a9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

