### PR TITLE
feat: enforce role-based auth and admin provisioning

### DIFF
--- a/api/auth/admin/create-user.js
+++ b/api/auth/admin/create-user.js
@@ -1,0 +1,187 @@
+/**
+ * Admin-only endpoint for provisioning new users.
+ *
+ * POST /api/auth/admin/create-user
+ * Headers: { Authorization: "Bearer <admin-token>" }
+ * Body: { email: string, password: string, role?: "admin" | "user" }
+ */
+
+const { sql } = require('@vercel/postgres');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const fs = require('fs');
+const path = require('path');
+
+const ALLOWED_ROLES = ['admin', 'user'];
+
+function respond(res, status, payload) {
+  return res.status(status).json(payload);
+}
+
+function normalizeRole(role = 'user') {
+  const normalized = role.toLowerCase();
+  if (!ALLOWED_ROLES.includes(normalized)) {
+    throw new Error(
+      `Invalid role "${role}". Allowed roles: ${ALLOWED_ROLES.join(', ')}`
+    );
+  }
+  return normalized;
+}
+
+async function createUserInDatabase(email, password, role) {
+  const existing = await sql`
+    SELECT id FROM users WHERE email = ${email}
+  `;
+
+  if (existing.rows.length > 0) {
+    return { success: false, status: 409, message: 'User already exists' };
+  }
+
+  const passwordHash = await bcrypt.hash(password, 12);
+
+  await sql`
+    INSERT INTO users (email, password_hash, role)
+    VALUES (${email}, ${passwordHash}, ${role})
+  `;
+
+  return { success: true, status: 201 };
+}
+
+async function createUserInMockStore(email, password, role) {
+  const mockPath = path.join(process.cwd(), 'mock-users.json');
+  let data = {};
+
+  try {
+    const content = await fs.promises.readFile(mockPath, 'utf8');
+    data = JSON.parse(content);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  if (data[email]) {
+    return { success: false, status: 409, message: 'User already exists' };
+  }
+
+  const passwordHash = await bcrypt.hash(password, 12);
+  const nextId =
+    Object.values(data).reduce(
+      (max, entry) => (entry.id && entry.id > max ? entry.id : max),
+      0
+    ) + 1;
+
+  data[email] = {
+    id: nextId,
+    email,
+    passwordHash,
+    role,
+    createdAt: new Date().toISOString(),
+    lastLogin: null,
+  };
+
+  await fs.promises.writeFile(mockPath, JSON.stringify(data, null, 2));
+  return { success: true, status: 201 };
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return respond(res, 405, {
+      success: false,
+      error: 'Method not allowed. Use POST.',
+    });
+  }
+
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return respond(res, 401, {
+        success: false,
+        error: 'Missing authentication token',
+      });
+    }
+
+    const token = authHeader.substring(7);
+
+    if (!process.env.JWT_SECRET) {
+      return respond(res, 500, {
+        success: false,
+        error: 'Server configuration error',
+      });
+    }
+
+    let decoded;
+    try {
+      decoded = jwt.verify(token, process.env.JWT_SECRET);
+    } catch (error) {
+      return respond(res, 401, {
+        success: false,
+        error: 'Invalid or expired token',
+      });
+    }
+
+    if ((decoded.role || 'user') !== 'admin') {
+      return respond(res, 403, {
+        success: false,
+        error: 'Admin privileges required',
+      });
+    }
+
+    const { email, password, role = 'user' } = req.body || {};
+
+    if (!email || !password) {
+      return respond(res, 400, {
+        success: false,
+        error: 'Email and password are required',
+      });
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return respond(res, 400, {
+        success: false,
+        error: 'Invalid email format',
+      });
+    }
+
+    if (password.length < 6) {
+      return respond(res, 400, {
+        success: false,
+        error: 'Password must be at least 6 characters',
+      });
+    }
+
+    let normalizedRole;
+    try {
+      normalizedRole = normalizeRole(role);
+    } catch (error) {
+      return respond(res, 400, {
+        success: false,
+        error: error.message,
+      });
+    }
+
+    const useDatabase = !!process.env.POSTGRES_URL;
+    const result = await (useDatabase
+      ? createUserInDatabase(email, password, normalizedRole)
+      : createUserInMockStore(email, password, normalizedRole));
+
+    if (!result.success) {
+      return respond(res, result.status, {
+        success: false,
+        error: result.message || 'Unable to create user',
+      });
+    }
+
+    return respond(res, 201, {
+      success: true,
+      message: 'User created successfully',
+    });
+  } catch (error) {
+    // Avoid leaking implementation details
+    return respond(res, 500, {
+      success: false,
+      error: 'Internal server error',
+    });
+  }
+};

--- a/docs/features/page-level-login/README.md
+++ b/docs/features/page-level-login/README.md
@@ -1,0 +1,27 @@
+# Page-Level Login Enhancements
+
+This branch implements role-aware authentication across the LCT dashboard. All HTML entrypoints now load `auth.js`, which verifies JWT tokens before rendering protected content. The shared script also exposes a `lct-auth-ready` event so feature-specific code can react once the current user is known.
+
+## Roles
+
+- `admin`: Can provision additional users and manage elevated tooling.
+- `user`: Standard dashboard access without administration privileges.
+
+Every token now embeds the `role` claim, and `auth.js` persists it in `localStorage` for front-end checks. Pages that require elevated access can define `window.lctAuthConfig = { requiredRole: 'admin' }` before loading `auth.js`.
+
+## Admin User Provisioning
+
+Settings now includes an admin-only card with a form that calls `POST /api/auth/admin/create-user`. The flow:
+
+1. Auth script verifies the current token and dispatches `lct-auth-ready`.
+2. Settings listens for the event, reveals the form only for admins, and wires up submission handlers.
+3. Admins can create either `admin` or `user` accounts. Passwords must be at least six characters.
+4. Responses surface inline feedback, and successes reuse the global toast.
+
+The API relies on Vercel Postgres when available and falls back to `mock-users.json` during local development. CLI helper `scripts/add-user.js` also supports a third `[role]` argument for seeding admins.
+
+## Verification
+
+- Manual: Attempt to load any page without a token → redirected to `login.html`.
+- Admin toggle: Log in as an admin, open Settings, and create a user. Log in as a standard user to confirm the admin card stays hidden.
+- API: `curl -X POST /api/auth/admin/create-user` with a non-admin token returns `403`.

--- a/mock-users.json
+++ b/mock-users.json
@@ -3,6 +3,7 @@
     "id": 1,
     "email": "arif.khan@vitraya.com",
     "passwordHash": "$2a$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewdBPj5J5K5K5K5K",
+    "role": "admin",
     "createdAt": "2025-10-12T10:35:24.517Z",
     "lastLogin": null
   }

--- a/scripts/setup-database-mock.js
+++ b/scripts/setup-database-mock.js
@@ -23,6 +23,7 @@ async function setupMockDatabase() {
         email: 'arif.khan@vitraya.com',
         passwordHash:
           '$2a$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewdBPj5J5K5K5K5K', // Mock hash for development password
+        role: 'admin',
         createdAt: new Date().toISOString(),
         lastLogin: null,
       },

--- a/scripts/setup-database.js
+++ b/scripts/setup-database.js
@@ -42,13 +42,22 @@ async function setupDatabase() {
         id SERIAL PRIMARY KEY,
         email VARCHAR(255) UNIQUE NOT NULL,
         password_hash TEXT NOT NULL,
+        role VARCHAR(20) NOT NULL DEFAULT 'user',
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         last_login TIMESTAMP
       );
     `;
 
     await client.query(createTableQuery);
-    console.log('✅ Users table created successfully');
+    console.log('✅ Users table created or verified successfully');
+
+    // Ensure role column exists on older tables
+    const ensureRoleColumnQuery = `
+      ALTER TABLE users
+      ADD COLUMN IF NOT EXISTS role VARCHAR(20) NOT NULL DEFAULT 'user';
+    `;
+    await client.query(ensureRoleColumnQuery);
+    console.log('✅ Role column ensured on users table');
 
     // Create index on email for faster lookups
     const createIndexQuery = `

--- a/src/app/analytics-dashboard.html
+++ b/src/app/analytics-dashboard.html
@@ -14,6 +14,7 @@
     <!-- LCT Design Tokens -->
     <link rel="stylesheet" href="assets/css/design-tokens.css">
 
+    <script src="auth.js"></script>
     <script>
         // Tailwind config for custom colors
         tailwind.config = {

--- a/src/app/brain-dumps.html
+++ b/src/app/brain-dumps.html
@@ -1035,6 +1035,7 @@
         </div>
     </div>
 
+    <script src="auth.js"></script>
     <script>
         // ============================================
         // BRAIN DUMPS APPLICATION

--- a/src/app/index.html
+++ b/src/app/index.html
@@ -621,6 +621,7 @@
 
     <div class="toast" id="toast">Saved</div>
 
+    <script src="auth.js"></script>
     <script>
         const checklistData = [
             {

--- a/src/app/login.html
+++ b/src/app/login.html
@@ -272,7 +272,12 @@
                     localStorage.setItem('lctAuthToken', data.token);
                     
                     // Store user info
-                    localStorage.setItem('lctUser', JSON.stringify(data.user));
+                    const userInfo = Object.assign(
+                        {},
+                        data.user,
+                        { role: (data.user && data.user.role) || 'user' }
+                    );
+                    localStorage.setItem('lctUser', JSON.stringify(userInfo));
                     
                     // Set remember me (extend token if needed)
                     if (rememberMe) {
@@ -324,6 +329,14 @@
                 });
                 
                 if (response.ok) {
+                    const data = await response.json().catch(() => null);
+                    if (data && data.user) {
+                        const normalizedRole = data.user.role || 'user';
+                        const storedUser = Object.assign({}, data.user, {
+                            role: normalizedRole
+                        });
+                        localStorage.setItem('lctUser', JSON.stringify(storedUser));
+                    }
                     // Token is valid, redirect to dashboard
                     window.location.href = '/';
                 } else {

--- a/src/app/settings.html
+++ b/src/app/settings.html
@@ -99,6 +99,11 @@
             margin-bottom: 12px;
         }
 
+        .subtle-text {
+            font-size: 13px;
+            color: #737373;
+        }
+
         .btn {
             padding: 6px 12px;
             border: 1px solid #e5e5e5;
@@ -166,6 +171,51 @@
             color: #525252;
             margin-top: 12px;
         }
+
+        .admin-card {
+            margin-top: 24px;
+        }
+
+        .admin-form-group {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            margin-bottom: 16px;
+        }
+
+        .admin-form-group label {
+            font-size: 13px;
+            font-weight: 600;
+            color: #0a0a0a;
+        }
+
+        .admin-form-group input,
+        .admin-form-group select {
+            border: 1px solid #e5e5e5;
+            border-radius: 6px;
+            padding: 8px 10px;
+            font-size: 14px;
+        }
+
+        .admin-section-note {
+            font-size: 12px;
+            color: #737373;
+            margin-top: 8px;
+        }
+
+        .form-feedback {
+            font-size: 13px;
+            margin-top: 12px;
+            color: #525252;
+        }
+
+        .form-feedback.is-success {
+            color: #047857;
+        }
+
+        .form-feedback.is-error {
+            color: #b91c1c;
+        }
     </style>
 </head>
 <body>
@@ -178,6 +228,7 @@
         <a href="documentation.html">Documentation</a>
         <a href="brain-dumps.html">Brain Dumps</a>
         <a href="settings.html" class="active" aria-current="page">Settings</a>
+        <a href="#" id="logout-link" style="color: #dc2626; margin-left: auto;">Logout</a>
     </nav>
 
     <div class="container">
@@ -219,10 +270,39 @@
             <p><strong>Organization:</strong> LCT Group & Vitraya Technologies</p>
             <p style="margin-top: 12px;"><a href="https://github.com/ak-eyther/LCT-commit" target="_blank">View on GitHub</a></p>
         </div>
+
+        <div class="card admin-card" id="admin-user-card" hidden>
+            <h2>User Management</h2>
+            <p class="subtle-text">Admins can provision accounts and assign roles. Standard users cannot see this section.</p>
+            <form id="create-user-form" novalidate>
+                <div class="admin-form-group">
+                    <label for="new-user-email">User email</label>
+                    <input type="email" id="new-user-email" name="new-user-email" placeholder="user@example.com" required>
+                </div>
+                <div class="admin-form-group">
+                    <label for="new-user-password">Temporary password</label>
+                    <input type="password" id="new-user-password" name="new-user-password" placeholder="Minimum 6 characters" minlength="6" required>
+                </div>
+                <div class="admin-form-group">
+                    <label for="new-user-role">Role</label>
+                    <select id="new-user-role" name="new-user-role">
+                        <option value="user">Standard user</option>
+                        <option value="admin">Admin</option>
+                    </select>
+                    <p class="admin-section-note">Admins can create new accounts and view admin-only tooling. Standard users only access dashboards.</p>
+                </div>
+                <div style="display: flex; gap: 12px; justify-content: flex-end;">
+                    <button class="btn" type="button" id="reset-admin-form">Clear</button>
+                    <button class="btn btn-primary" type="submit" id="create-user-submit">Create user</button>
+                </div>
+            </form>
+            <p class="form-feedback" id="admin-feedback" role="status" aria-live="polite"></p>
+        </div>
     </div>
 
     <div class="toast" id="toast">Saved</div>
 
+    <script src="auth.js"></script>
     <script>
         function showToast(msg) {
             const toast = document.getElementById('toast');
@@ -298,14 +378,105 @@
             }
         }
 
-        // Event listeners
-        document.getElementById('export-json').addEventListener('click', exportJSON);
-        document.getElementById('export-csv').addEventListener('click', exportCSV);
-        document.getElementById('import-json').addEventListener('click', () => {
-            document.getElementById('importFile').click();
+        function resetAdminForm() {
+            document.getElementById('create-user-form').reset();
+            const feedback = document.getElementById('admin-feedback');
+            feedback.textContent = '';
+            feedback.className = 'form-feedback';
+        }
+
+        const ADMIN_SECTION_ID = 'admin-user-card';
+        let adminSectionActivated = false;
+
+        function showAdminSection(user) {
+            if (!user || user.role !== 'admin') {
+                return;
+            }
+
+            const card = document.getElementById(ADMIN_SECTION_ID);
+            if (!card || adminSectionActivated) {
+                return;
+            }
+
+            adminSectionActivated = true;
+            card.hidden = false;
+
+            const form = document.getElementById('create-user-form');
+            const feedback = document.getElementById('admin-feedback');
+            const submitButton = document.getElementById('create-user-submit');
+
+            form.addEventListener('submit', async event => {
+                event.preventDefault();
+
+                feedback.textContent = '';
+                feedback.className = 'form-feedback';
+
+                const email = document.getElementById('new-user-email').value.trim();
+                const password = document.getElementById('new-user-password').value;
+                const role = document.getElementById('new-user-role').value;
+
+                if (!email || !password) {
+                    feedback.textContent = 'Email and password are required.';
+                    feedback.classList.add('is-error');
+                    return;
+                }
+
+                submitButton.disabled = true;
+
+                try {
+                    const token = localStorage.getItem('lctAuthToken');
+                    const response = await fetch('/api/auth/admin/create-user', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json',
+                            Authorization: `Bearer ${token}`,
+                        },
+                        body: JSON.stringify({ email, password, role }),
+                    });
+
+                    const data = await response.json().catch(() => ({}));
+
+                    if (response.ok && data.success) {
+                        feedback.textContent = 'User created successfully. Share the temporary password with the new user.';
+                        feedback.classList.add('is-success');
+                        showToast('User account created');
+                        form.reset();
+                    } else {
+                        feedback.textContent = data.error || 'Unable to create user.';
+                        feedback.classList.add('is-error');
+                    }
+                } catch (error) {
+                    feedback.textContent = 'Network error. Please try again.';
+                    feedback.classList.add('is-error');
+                } finally {
+                    submitButton.disabled = false;
+                }
+            });
+
+            document
+                .getElementById('reset-admin-form')
+                .addEventListener('click', resetAdminForm);
+        }
+
+        function initialiseSettingsPage() {
+            document.getElementById('export-json').addEventListener('click', exportJSON);
+            document.getElementById('export-csv').addEventListener('click', exportCSV);
+            document.getElementById('import-json').addEventListener('click', () => {
+                document.getElementById('importFile').click();
+            });
+            document.getElementById('importFile').addEventListener('change', importData);
+            document.getElementById('clear-data').addEventListener('click', clearAllData);
+
+            const existingUser = typeof getCurrentUser === 'function' ? getCurrentUser() : null;
+            if (existingUser) {
+                showAdminSection(existingUser);
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', initialiseSettingsPage);
+        window.addEventListener('lct-auth-ready', event => {
+            showAdminSection(event.detail);
         });
-        document.getElementById('importFile').addEventListener('change', importData);
-        document.getElementById('clear-data').addEventListener('click', clearAllData);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- require auth.js on every page and propagate role data from /api/auth/verify
- embed roles in JWTs, add admin-only API for provisioning users, and update scripts to seed roles
- expose admin-only user management UI in settings plus docs for the new workflow

## Verification
- manual: hit /settings.html without token → redirected to login
- manual: login as admin, create user via UI → success toast, non-admin cannot see card


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Admins can create user accounts (email, temp password, role) from the Settings page.
  - Role-based access across pages; admin-only sections reveal automatically.
  - Added Logout link in navigation.

- Improvements
  - More reliable authentication with retry and consistent role persistence.
  - Earlier auth initialization on app pages.
  - Clearer form validation, success/error toasts, and reset behavior in Settings.

- Bug Fixes
  - More accurate error messaging and status handling during authentication and user creation.

- Documentation
  - Added guide for page-level login, roles, admin UI, and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->